### PR TITLE
fix: re populate higher priority caches when a key is found in lower ones

### DIFF
--- a/src/multi-caching.ts
+++ b/src/multi-caching.ts
@@ -25,12 +25,23 @@ export function multiCaching<Caches extends Cache[]>(
     del: async (key) => {
       await Promise.all(caches.map((cache) => cache.del(key)));
     },
-    async wrap<T>(key: string, fn: () => Promise<T>): Promise<T> {
-      const value = await get<T>(key);
+    async wrap<T>(key: string, fn: () => Promise<T>, ttl?: Ttl): Promise<T> {
+      let value: T | undefined;
+      let i = 0;
+      for (; i < caches.length; i++) {
+        try {
+          value = await caches[i].get<T>(key);
+          if (value !== undefined) break;
+        } catch (e) {}
+      }
       if (value === undefined) {
         const result = await fn();
-        await set<T>(key, result);
+        await set<T>(key, result, ttl);
         return result;
+      } else {
+        for (let j = 0; j < i; j++) {
+          await caches[j].set(key, value, ttl);
+        }
       }
       return value;
     },


### PR DESCRIPTION
Fixes #253 