### PR TITLE
Docs : Add ttl unit change in CHANGELOG and fix typo in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,28 +14,29 @@
 
   - Add ttl argument in wrap method
 
-- 5.0.1
+- 5.0.1 (2022-10-09)
 
   - Fix unexported types
 
-- 5.0.0
+- 5.0.0 (2022-09-29)
 
   - Refactor to promise and typescript (#203).
+    - Change `ttl` param unit to milliseconds
     - Remove `ignoreCacheErrors`: not valid in async/await context
     - Remove `refreshThreshold`: use lower ttl
     - Remove callbackFiller
     - Use function as `FactoryStore`
     - Remove multiple wrap
 
-- 4.1.0
+- 4.1.0 (2022-07-07)
 
   - Support for TTL as third arg in memory store set function (#196). - @ZirionNeft
 
-- 4.0.1
+- 4.0.1 (2022-06-03)
 
   - Fix TTL option bug for memory cache (#194). - @anchan828
 
-- 4.0.0
+- 4.0.0 (2022-06-01)
 
   - Upgrade to lru-cache 7.x (#193). - @orgads
     - This has a breaking change in memoryCache.dump().

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ import { caching } from 'cache-manager';
 
 const memoryCache = await caching('memory', {
   max: 100,
-  ttl: 10 * 1000 /*miliseconds*/,
+  ttl: 10 * 1000 /*milliseconds*/,
 });
 
-const ttl = 5 * 1000; /*miliseconds*/
+const ttl = 5 * 1000; /*milliseconds*/
 await memoryCache.set('foo', 'bar', ttl);
 
 console.log(await memoryCache.get('foo'));


### PR DESCRIPTION
Minor changes in docs :
  - CHANGELOG.md : 
    - Add `ttl` unit change on 5.0.0 changes
    - Add dates for versions from 4.0.0 to 5.0.1
  - README.md : 
    - Change `miliseconds` => `milliseconds`