### PR TITLE
Introduced typescript alias type for ttl

### DIFF
--- a/src/caching.ts
+++ b/src/caching.ts
@@ -1,18 +1,18 @@
 import { MemoryCache, MemoryConfig, memoryStore } from './stores';
 
 export type Config = {
-  ttl?: Ttl;
+  ttl?: Milliseconds;
   isCacheable?: (val: unknown) => boolean;
 };
 
-export type Ttl = number;
+export type Milliseconds = number;
 
 export type Store = {
   get<T>(key: string): Promise<T | undefined>;
-  set<T>(key: string, data: T, ttl?: Ttl): Promise<void>;
+  set<T>(key: string, data: T, ttl?: Milliseconds): Promise<void>;
   del(key: string): Promise<void>;
   reset(): Promise<void>;
-  mset(args: [string, unknown][], ttl?: Ttl): Promise<void>;
+  mset(args: [string, unknown][], ttl?: Milliseconds): Promise<void>;
   mget(...args: string[]): Promise<unknown[]>;
   mdel(...args: string[]): Promise<void>;
   keys(pattern?: string): Promise<string[]>;
@@ -33,11 +33,11 @@ export type Stores<S extends Store, T extends object> =
 export type CachingConfig<T> = MemoryConfig | StoreConfig | FactoryConfig<T>;
 
 export type Cache<S extends Store = Store> = {
-  set: (key: string, value: unknown, ttl?: Ttl) => Promise<void>;
+  set: (key: string, value: unknown, ttl?: Milliseconds) => Promise<void>;
   get: <T>(key: string) => Promise<T | undefined>;
   del: (key: string) => Promise<void>;
   reset: () => Promise<void>;
-  wrap<T>(key: string, fn: () => Promise<T>, ttl?: Ttl): Promise<T>;
+  wrap<T>(key: string, fn: () => Promise<T>, ttl?: Milliseconds): Promise<T>;
   store: S;
 };
 


### PR DESCRIPTION
Improved the typing of the TTL type to Milliseconds. this is best practice for typescript (https://www.typescriptlang.org/docs/handbook/advanced-types.html#type-aliases) and helps developer to set the right unit  because of the IDE support. 

if your not sure if the ttl property is seconds or milliseconds you are now able to hover the property and get the unit

what do you think about this change?