### PR TITLE
feat: add mget(), mset(), mdel() to multiCache

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,29 @@ console.log(await multiCache.get('foo2'));
 
 // Delete from all caches
 await multiCache.del('foo2');
+
+// Sets multiple keys in all caches.
+// You can pass as many key, value tuples as you want
+await multiCache.mset(
+  [
+    ['foo', 'bar'],
+    ['foo2', 'bar2'],
+  ],
+  ttl
+);
+
+// mget() fetches from highest priority cache.
+// If the first cache does not return all the keys,
+// the next cache is fetched with the keys that were not found.
+// This is done recursively until either:
+// - all have been found
+// - all caches has been fetched
+console.log(await multiCache.mget('key', 'key2');
+// >> ['bar', 'bar2']
+
+// Delete keys with mdel() passing arguments...
+await multiCache.mdel('foo', 'foo2');
+
 ```
 
 See unit tests in [`test/multi-caching.test.ts`](./test/multi-caching.test.ts) for more information.

--- a/test/multi-caching.test.ts
+++ b/test/multi-caching.test.ts
@@ -91,6 +91,56 @@ describe('multiCaching', () => {
       });
     });
 
+    describe('mset()', () => {
+      it('lets us set multiple keys in all caches', async () => {
+        const keys = [faker.datatype.string(20), faker.datatype.string(20)];
+        const values = [faker.datatype.string(), faker.datatype.string()];
+        await multiCache.mset(
+          [
+            [keys[0], values[0]],
+            [keys[1], values[1]],
+          ],
+          defaultTtl,
+        );
+        await expect(memoryCache.get(keys[0])).resolves.toEqual(values[0]);
+        await expect(memoryCache2.get(keys[0])).resolves.toEqual(values[0]);
+        await expect(memoryCache3.get(keys[0])).resolves.toEqual(values[0]);
+        await expect(memoryCache.get(keys[1])).resolves.toEqual(values[1]);
+        await expect(memoryCache2.get(keys[1])).resolves.toEqual(values[1]);
+        await expect(memoryCache3.get(keys[1])).resolves.toEqual(values[1]);
+      });
+    });
+
+    describe('mget()', () => {
+      it('lets us get multiple keys', async () => {
+        const keys = [faker.datatype.string(20), faker.datatype.string(20)];
+        const values = [faker.datatype.string(), faker.datatype.string()];
+        await multiCache.set(keys[0], values[0], defaultTtl);
+        await memoryCache3.set(keys[1], values[1], defaultTtl);
+        await expect(multiCache.mget(...keys)).resolves.toStrictEqual(values);
+      });
+    });
+
+    describe('mdel()', () => {
+      it('lets us delete multiple keys', async () => {
+        const keys = [faker.datatype.string(20), faker.datatype.string(20)];
+        const values = [faker.datatype.string(), faker.datatype.string()];
+        await multiCache.mset(
+          [
+            [keys[0], values[0]],
+            [keys[1], values[1]],
+          ],
+          defaultTtl,
+        );
+        await expect(multiCache.mget(...keys)).resolves.toStrictEqual(values);
+        await multiCache.mdel(...keys);
+        await expect(multiCache.mget(...keys)).resolves.toStrictEqual([
+          undefined,
+          undefined,
+        ]);
+      });
+    });
+
     describe('when cache fails', () => {
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       const empty = (async () => {}) as never;


### PR DESCRIPTION
Fix for #361. (clone of #366 but with a clean commit)

The implementation is similar to the functionality that existed in previous versions and is missing in v5. However, mset takes the same array-style arguments as the single-store version in v5 (as opposed to the pre-v5-style with key, value pair argument list).