### PR TITLE
sizeCalculation key,value swap

### DIFF
--- a/src/stores/memory.ts
+++ b/src/stores/memory.ts
@@ -17,7 +17,7 @@ type Pre = LRUCache.OptionsTTLLimit<string, any, unknown>;
 type Options = Omit<Pre, 'ttlAutopurge'> & Partial<Pick<Pre, 'ttlAutopurge'>>;
 export type MemoryConfig = {
   max?: number;
-  sizeCalculation?: (key: string, value: unknown) => number;
+  sizeCalculation?: (value: unknown, key: string) => number;
   shouldCloneBeforeSet?: boolean;
 } & Options &
   Config;


### PR DESCRIPTION
type MemoryConfig in memoryStore is incorrect and could cause some confusion (it did for me a bit)

this is the type in node-lru-cache package
[https://github.com/isaacs/node-lru-cache/blob/main/src/index.ts#L219](https://github.com/isaacs/node-lru-cache/blob/main/src/index.ts#L219)

as you can see value is first annd key is second.