### PR TITLE
test(memory store): sizeCalculation

### DIFF
--- a/src/stores/memory.ts
+++ b/src/stores/memory.ts
@@ -26,6 +26,7 @@ export type MemoryStore = Store & {
   get size(): number;
   dump: LRU['dump'];
   load: LRU['load'];
+  calculatedSize: LRU['calculatedSize'];
 };
 export type MemoryCache = Cache<MemoryStore>;
 
@@ -76,6 +77,9 @@ export function memoryStore(args?: MemoryConfig): MemoryStore {
       const ttl = opt !== undefined ? opt : lruOpts.ttl;
 
       lruCache.set(key, value, { ttl });
+    },
+    get calculatedSize() {
+      return lruCache.calculatedSize;
     },
     /**
      * This method is not available in the caching modules.

--- a/test/caching.test.ts
+++ b/test/caching.test.ts
@@ -20,8 +20,8 @@ describe('caching', () => {
   describe('get() and set()', () => {
     beforeEach(async () => {
       cache = await caching('memory');
-      key = faker.random.alpha(20);
-      value = faker.datatype.string();
+      key = faker.string.alpha(20);
+      value = faker.string.sample();
     });
 
     it('lets us set and get data in cache', async () => {
@@ -60,10 +60,10 @@ describe('caching', () => {
     const store = 'memory';
 
     beforeEach(async () => {
-      key = faker.datatype.string(20);
-      value = faker.datatype.string();
-      key2 = faker.datatype.string(20);
-      value2 = faker.datatype.string();
+      key = faker.string.sample(20);
+      value = faker.string.sample();
+      key2 = faker.string.sample(20);
+      value2 = faker.string.sample();
 
       cache = await caching(store, {
         ttl: defaultTtl,
@@ -104,8 +104,8 @@ describe('caching', () => {
   describe('del()', function () {
     beforeEach(async () => {
       cache = await caching('memory');
-      key = faker.datatype.string(20);
-      value = faker.datatype.string();
+      key = faker.string.sample(20);
+      value = faker.string.sample();
       await cache.set(key, value, defaultTtl);
     });
 
@@ -121,8 +121,8 @@ describe('caching', () => {
 
       beforeEach(async () => {
         cache = await caching('memory');
-        key2 = faker.datatype.string(20);
-        value2 = faker.datatype.string();
+        key2 = faker.string.sample(20);
+        value2 = faker.string.sample();
         await cache.store.mset(
           [
             [key, value],
@@ -152,11 +152,11 @@ describe('caching', () => {
 
     beforeEach(async () => {
       cache = await caching('memory');
-      key = faker.datatype.string(20);
-      value = faker.datatype.string();
+      key = faker.string.sample(20);
+      value = faker.string.sample();
       await cache.set(key, value);
-      key2 = faker.datatype.string(20);
-      value2 = faker.datatype.string();
+      key2 = faker.string.sample(20);
+      value2 = faker.string.sample();
       await cache.set(key2, value2);
     });
 
@@ -178,9 +178,8 @@ describe('caching', () => {
       savedKeys = (
         await Promise.all(
           Array.from({ length: keyCount }).map(async (_, i) => {
-            const key =
-              (i % 3 === 0 ? 'prefix' : '') + faker.datatype.string(20);
-            value = faker.datatype.string();
+            const key = (i % 3 === 0 ? 'prefix' : '') + faker.string.sample(20);
+            value = faker.string.sample();
             await cache.set(key, value);
             return key;
           }),

--- a/test/multi-caching.test.ts
+++ b/test/multi-caching.test.ts
@@ -22,8 +22,8 @@ describe('multiCaching', () => {
   let key: string;
 
   async function multiMset() {
-    const keys = [faker.datatype.string(20), faker.datatype.string(20)];
-    const values = [faker.datatype.string(), faker.datatype.string()];
+    const keys = [faker.string.sample(20), faker.string.sample(20)];
+    const values = [faker.string.sample(), faker.string.sample()];
     await multiCache.mset(
       [
         [keys[0], values[0]],
@@ -48,7 +48,7 @@ describe('multiCaching', () => {
       ttl,
     });
 
-    key = faker.datatype.string(20);
+    key = faker.string.sample(20);
   });
 
   describe('get(), set(), del(), reset(), mget(), mset()', () => {
@@ -56,8 +56,8 @@ describe('multiCaching', () => {
 
     beforeEach(() => {
       multiCache = multiCaching([memoryCache, memoryCache2, memoryCache3]);
-      key = faker.datatype.string(20);
-      value = faker.datatype.string();
+      key = faker.string.sample(20);
+      value = faker.string.sample();
     });
 
     describe('set()', () => {
@@ -127,7 +127,7 @@ describe('multiCaching', () => {
       it('lets us get multiple undefined', async () => {
         const len = 4;
         await multiMset();
-        const args = faker.datatype.array(len).map((x) => '' + x);
+        const args = new Array(len).fill('').map(() => faker.string.sample());
         await expect(multiCache.mget(...args)).resolves.toStrictEqual(
           new Array(len).fill(undefined),
         );

--- a/test/stores/memory.test.ts
+++ b/test/stores/memory.test.ts
@@ -38,6 +38,66 @@ describe('memory store', () => {
     });
   });
 
+  describe('sizeCalculation', function () {
+    let store: MemoryStore;
+
+    beforeEach(() => {
+      store = memoryStore({
+        ttl: 0,
+        maxSize: 10,
+        sizeCalculation: (v, k) => JSON.stringify(v).length + k.length,
+      });
+    });
+
+    it('calculatedSize and sizeCalcuation must be the same', async function () {
+      await store.set('foo', 'bar');
+
+      expect(store.calculatedSize).toEqual(
+        JSON.stringify('bar').length + 'foo'.length,
+      );
+    });
+
+    it('should cache new value and drop the old one(s) if maxSize is reached', async function () {
+      const key = 'foo';
+      const value = 'bar';
+      await store.set(key, value);
+
+      const cache = await store.get(key);
+      expect(cache).toEqual(value);
+
+      const newKey = 'foo2';
+      const newValue = 'bar2';
+
+      await store.set(newKey, newValue);
+
+      const first = await store.get(key);
+      const second = await store.get(newKey);
+
+      expect(first).toBeUndefined();
+      expect(second).toEqual(newValue);
+    });
+
+    it('should not cache something greater than maxSize', async function () {
+      const key = 'foo';
+      const value = 'bar'.repeat(5);
+      await store.set(key, value);
+
+      const cache = await store.get(key);
+      expect(cache).toBeUndefined();
+    });
+
+    it('should throw if invalid sizeCalculation function is passed', () => {
+      expect(() =>
+        memoryStore({
+          // @ts-expect-error testing if this actually throws
+          sizeCalculation: () => {
+            return 'invalid-type';
+          },
+        }),
+      ).toThrow();
+    });
+  });
+
   describe('keyCount', function () {
     let memoryCache: MemoryStore;
 
@@ -62,7 +122,7 @@ describe('memory store', () => {
     describe('when cache misses', () => {
       let key: string;
       beforeEach(() => {
-        key = faker.datatype.string();
+        key = faker.string.sample();
       });
 
       function getCachedObject() {
@@ -215,10 +275,10 @@ describe('memory store', () => {
         const defaultTtl = 100;
 
         beforeEach(async () => {
-          key = faker.datatype.string(20);
-          value = faker.datatype.string();
-          key2 = faker.datatype.string(20);
-          value2 = faker.datatype.string();
+          key = faker.string.sample(20);
+          value = faker.string.sample();
+          key2 = faker.string.sample(20);
+          value2 = faker.string.sample();
 
           cache = await caching('memory', {
             shouldCloneBeforeSet: false,
@@ -267,10 +327,10 @@ describe('memory store', () => {
     let value2: string;
 
     beforeEach(function () {
-      key1 = faker.datatype.string(20);
-      value1 = faker.datatype.string();
-      key2 = faker.datatype.string(20);
-      value2 = faker.datatype.string();
+      key1 = faker.string.sample(20);
+      value1 = faker.string.sample();
+      key2 = faker.string.sample(20);
+      value2 = faker.string.sample();
     });
 
     it('lets us dump data', () => {
@@ -295,10 +355,10 @@ describe('memory store', () => {
     let data: Parameters<typeof memoryCache.load>[number];
 
     beforeEach(function () {
-      key1 = faker.datatype.string(20);
-      value1 = faker.datatype.string();
-      key2 = faker.datatype.string(20);
-      value2 = faker.datatype.string();
+      key1 = faker.string.sample(20);
+      value1 = faker.string.sample();
+      key2 = faker.string.sample(20);
+      value2 = faker.string.sample();
       data = [
         [key1, { value: value1 }],
         [key2, { value: value2 }],


### PR DESCRIPTION
added tests for sizeCalculation (regarding [this](https://github.com/node-cache-manager/node-cache-manager/pull/480#issuecomment-1567218560))

changed out faker deprecated methods with the recommended replacements

added lru-cache's calculatedSize to memoryStore example and wrote a test for it