### PR TITLE
feat: support sync cache creation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['16', '18', '20']
+        node-version: ['18', '20']
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -84,6 +84,32 @@ You can use your own custom store by creating one with the same API as the built
 - [Example Custom Store redis](https://github.com/node-cache-manager/node-cache-manager-redis-yet)
 - [Example Custom Store ioredis](https://github.com/node-cache-manager/node-cache-manager-ioredis-yet)
 
+#### Create single cache store synchronously
+
+As `caching()` requires async functionality to resolve some stores, this is not well-suited to use for default function/constructor parameters etc.
+
+If you need to create a cache store synchronously, you can instead use `createCache()`:
+
+```typescript
+import { createCache, memoryStore } from 'node-cache-manager';
+
+// Create memory cache synchronously
+const memoryCache = createCache(memoryStore(), {
+  max: 100,
+  ttl: 10 * 1000 /*milliseconds*/,
+});
+
+// Default parameter in function
+function myService(cache = createCache(memoryStore())) {}
+
+// Default parameter in class constructor
+const DEFAULT_CACHE = createCache(memoryStore(), { ttl: 60 * 1000 });
+// ...
+class MyService {
+  constructor(private cache = DEFAULT_CACHE) {}
+}
+```
+
 ### Multi-Store
 
 ```typescript

--- a/test/caching.test.ts
+++ b/test/caching.test.ts
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker';
 import promiseCoalesce from 'promise-coalesce';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { Cache, MemoryConfig, caching, memoryStore } from '../src';
+import { caching, Cache, MemoryConfig, memoryStore, createCache } from '../src';
 import { sleep } from './utils';
 
 // Allow the module to be mocked so we can assert
@@ -386,6 +386,18 @@ describe('caching', () => {
           return cache.wrap('refreshThreshold', async () => 3);
         })(),
       ).resolves.toEqual(1);
+    });
+  });
+});
+
+describe('createCache', () => {
+  it('should create cache instance by store', async () => {
+    const store = memoryStore();
+    const cache1 = await caching(store);
+    const cache2 = createCache(store);
+    expect(cache1.store).toBe(cache2.store);
+    Object.entries(cache1).forEach(([key, value]) => {
+      expect(cache2[key as keyof Cache].toString()).toBe(value.toString());
     });
   });
 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/node-cache-manager/node-cache-manager/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Add non-async `createCache()` that `caching()` uses to set up methods (keep current functionality intact).

Having `createCache()` as addition to `caching()` allows devs to create cache instances synchronously, and i.e use as default params in methods:

```ts
/** Awesome service that will use memory store as default cache, if nothing else specified */ 
class MyItemService {
   constructor(public cache = createCache(memoryStore())) { }
}
```  
