### PR TITLE
fix(caching): coalesce concurrent requests to `wrap` function

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   "license": "MIT",
   "dependencies": {
     "lodash.clonedeep": "^4.5.0",
-    "lru-cache": "^10.0.1"
+    "lru-cache": "^10.0.1",
+    "promise-coalesce": "^1.1.1"
   },
   "devDependencies": {
     "@faker-js/faker": "8.1.0",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/node-cache-manager/node-cache-manager/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fixes #417

In the `v4.x` version, the `caching.wrap()` function would coalesce multiple concurrent requests to minimize how many times the generator function was invoked. This was a helpful optimization to reduce load on downstream systems like databases and APIs.

This pull request adds that cache miss relief logic back by using the [promise-coalesce](https://github.com/douglascayers/promise-coalesce) module, which is said logic in a generic, reusable function.

For tests, the `#417` issue test demonstrates the undesired behavior. The updated `wrap()` tests demonstrate the desired behavior by coalescing requests.

Thanks