### PR TITLE
fix(refreshThreshold): don't run if ttl is -1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# node-cache-manager 
+# node-cache-manager
+
 [![codecov](https://codecov.io/gh/node-cache-manager/node-cache-manager/branch/master/graph/badge.svg?token=ZV3G5IFigq)](https://codecov.io/gh/node-cache-manager/node-cache-manager)
 [![tests](https://github.com/node-cache-manager/node-cache-manager/actions/workflows/test.yml/badge.svg)](https://github.com/node-cache-manager/node-cache-manager/actions/workflows/test.yml)
 [![license](https://img.shields.io/github/license/node-cache-manager/node-cache-manager)](https://github.com/node-cache-manager/node-cache-manager/blob/master/LICENSE)
@@ -111,7 +112,7 @@ await multiCache.mset(
     ['foo', 'bar'],
     ['foo2', 'bar2'],
   ],
-  ttl
+  ttl,
 );
 
 // mget() fetches from highest priority cache.
@@ -140,9 +141,10 @@ following same rules as standard fetching. In the meantime, the system will retu
 
 NOTES:
 
-* In case of multicaching, the store that will be checked for refresh is the one where the key will be found first (highest priority).
-* If the threshold is low and the worker function is slow, the key may expire and you may encounter a racing condition with updating values.
-* The background refresh mechanism currently does not support providing multiple keys to `wrap` function.
+- In case of multicaching, the store that will be checked for refresh is the one where the key will be found first (highest priority).
+- If the threshold is low and the worker function is slow, the key may expire and you may encounter a racing condition with updating values.
+- The background refresh mechanism currently does not support providing multiple keys to `wrap` function.
+- If no `ttl` is set for the key, the refresh mechanism will not be triggered. For redis, the `ttl` is set to -1 by default.
 
 For example, pass the refreshThreshold to `caching` like this:
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ await multiCache.mset(
     ['foo', 'bar'],
     ['foo2', 'bar2'],
   ],
-  ttl,
+  ttl
 );
 
 // mget() fetches from highest priority cache.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# node-cache-manager
-
+# node-cache-manager 
 [![codecov](https://codecov.io/gh/node-cache-manager/node-cache-manager/branch/master/graph/badge.svg?token=ZV3G5IFigq)](https://codecov.io/gh/node-cache-manager/node-cache-manager)
 [![tests](https://github.com/node-cache-manager/node-cache-manager/actions/workflows/test.yml/badge.svg)](https://github.com/node-cache-manager/node-cache-manager/actions/workflows/test.yml)
 [![license](https://img.shields.io/github/license/node-cache-manager/node-cache-manager)](https://github.com/node-cache-manager/node-cache-manager/blob/master/LICENSE)
@@ -141,10 +140,10 @@ following same rules as standard fetching. In the meantime, the system will retu
 
 NOTES:
 
-- In case of multicaching, the store that will be checked for refresh is the one where the key will be found first (highest priority).
-- If the threshold is low and the worker function is slow, the key may expire and you may encounter a racing condition with updating values.
-- The background refresh mechanism currently does not support providing multiple keys to `wrap` function.
-- If no `ttl` is set for the key, the refresh mechanism will not be triggered. For redis, the `ttl` is set to -1 by default.
+* In case of multicaching, the store that will be checked for refresh is the one where the key will be found first (highest priority).
+* If the threshold is low and the worker function is slow, the key may expire and you may encounter a racing condition with updating values.
+* The background refresh mechanism currently does not support providing multiple keys to `wrap` function.
+* If no `ttl` is set for the key, the refresh mechanism will not be triggered. For redis, the `ttl` is set to -1 by default.
 
 For example, pass the refreshThreshold to `caching` like this:
 

--- a/src/caching.ts
+++ b/src/caching.ts
@@ -89,7 +89,7 @@ export async function caching<S extends Store, T extends object = never>(
       } else if (args?.refreshThreshold) {
         const cacheTTL = typeof ttl === 'function' ? ttl(value) : ttl;
         const remainingTtl = await store.ttl(key);
-        if (remainingTtl < args.refreshThreshold) {
+        if (remainingTtl !== -1 && remainingTtl < args.refreshThreshold) {
           fn().then((result) => store.set<T>(key, result, cacheTTL));
         }
       }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/node-cache-manager/node-cache-manager/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix)

In stores like redis, if no `ttl` value is set, `store.ttl(key)` returns `-1`. This causes an issue with the `refreshThreshold` feature, where the comparison mentioned below will always lead to running the function

https://github.com/node-cache-manager/node-cache-manager/blob/2eca5a0c6c905fe706ed9eaca9152dedd512ef7e/src/caching.ts#L92

I've added an additional check to check for `-1` value, and not run the function again.

Note: Wasn't sure where to add test for this, please let me know if I need to. I have tested this manually with my work project
