### PR TITLE
fix: exclude sourcemap when package publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist"
+    "dist/**/*.js",
+    "dist/**/*.d.ts"
   ],
   "scripts": {
     "build": "rm -rf dist && tsc -p tsconfig.build.json",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/node-cache-manager/node-cache-manager/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Sourcemap files are ignored when publishing because source paths are specified in them. For example, v8 module will search for the source code path according to the sourcemap when executing the coverage command in the typescript environment. If it is not found, an error will be reported.

Just publishing the compiled js and d.ts files is enough.

like [this](https://github.com/midwayjs/midway/actions/runs/7170370531/job/19522952358?pr=3492).
![image](https://github.com/node-cache-manager/node-cache-manager/assets/418820/a9ec6276-309d-45a1-b135-0cdfea12e780)

related: https://github.com/midwayjs/midway/pull/3492


@jaredwray

