### PR TITLE
Ability to catch promise rejections from background refreshes

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,10 @@ const memoryCache = await caching('memory', {
   max: 100,
   ttl: 10 * 1000 /*milliseconds*/,
   refreshThreshold: 3 * 1000 /*milliseconds*/,
+  
+  /* optional, but if not set, background refresh error will be an unhandled
+   * promise rejection, which might crash your node process */
+  onBackgroundRefreshError: (error) => { /* log or otherwise handle error */ }
 });
 ```
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,1 +1,25 @@
+import process from 'node:process';
+
 export const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+export const disableExistingExceptionListeners = () => {
+  const uncaughtExceptionListeners = process.rawListeners(
+    'uncaughtException',
+  ) as NodeJS.UncaughtExceptionListener[];
+  const unhandledRejectionListeners = process.rawListeners(
+    'unhandledRejection',
+  ) as NodeJS.UnhandledRejectionListener[];
+
+  process.removeAllListeners('uncaughtException');
+  process.removeAllListeners('unhandledRejection');
+
+  /* restore listeners */
+  return () => {
+    uncaughtExceptionListeners.forEach((listener) =>
+      process.addListener('uncaughtException', listener),
+    );
+    unhandledRejectionListeners.forEach((listener) =>
+      process.addListener('unhandledRejection', listener),
+    );
+  };
+};


### PR DESCRIPTION
This PR introduces `onBackgroundRefreshError` configuration option, which makes it possible to handle promise rejections originating from background refreshes.

As it stands now, depending on your Node version, process might crash. `process.on('uncaughtException', ...)` fixes that, but we missed a bit more... targeted approach to handling these errors, so here is a PR. 